### PR TITLE
Call super class setMinimumDateTime and setMaximumDateTime methods in DateTimeEdit widget

### DIFF
--- a/pyqttoolkit/views/datetime.py
+++ b/pyqttoolkit/views/datetime.py
@@ -68,9 +68,11 @@ class DateTimeEdit(QDateTimeEdit):
     
     def setMinimumDateTime(self, min_date):
         self._min_date = min_date
+        super().setMinimumDateTime(min_date)
     
     def setMaximumDateTime(self, max_date):
         self._max_date = max_date
+        super().setMaximumDateTime(max_date)
     
     @auto_property(QDateTime)
     def value(self):


### PR DESCRIPTION
Fixes #https://github.com/BitBloomTech/Sift/issues/1010

This change disables invalid dates once `max` and/or `min` date times are set so invalid dates are no longer clickable