### PR TITLE
Allow project manager to provide module window title

### DIFF
--- a/pyqttoolkit/modules/module.py
+++ b/pyqttoolkit/modules/module.py
@@ -33,6 +33,10 @@ class ModuleBase(QObject):
         return self._id
 
     @property
+    def title(self):
+        return self._id
+
+    @property
     def launcher_config(self):
         return self._launcher_config
     

--- a/pyqttoolkit/services/module_service.py
+++ b/pyqttoolkit/services/module_service.py
@@ -111,9 +111,7 @@ class ModuleService(QObject):
         return window
 
     def _create_sub_module(self, id_):
-        title = self._project_manager.get_module_window_title(id_)\
-            if hasattr(self._project_manager, 'get_module_window_title') else id_
-        window = ModuleWindow(self._theme_manager, title)
+        window = ModuleWindow(self._theme_manager, self._registered_modules[id_].title)
         model = self._dependency_container.resolve(
             self._registered_modules[id_].model_type,
             {'parent': window, 'module_id': id_}

--- a/pyqttoolkit/services/module_service.py
+++ b/pyqttoolkit/services/module_service.py
@@ -111,7 +111,9 @@ class ModuleService(QObject):
         return window
 
     def _create_sub_module(self, id_):
-        window = ModuleWindow(self._theme_manager, id_)
+        title = self._project_manager.get_module_window_title(id_)\
+            if hasattr(self._project_manager, 'get_module_window_title') else id_
+        window = ModuleWindow(self._theme_manager, title)
         model = self._dependency_container.resolve(
             self._registered_modules[id_].model_type,
             {'parent': window, 'module_id': id_}


### PR DESCRIPTION
I want to show file information in the window title of sub-modules. Currently, the module service has a monopoly on these titles (the module ID). Therefore, the project manager needs a way to influence the title.

Not sure if the way I've implemented is the best. It's extensible, but not sure if I'm giving responsibilities to the prohject manager that it shouldn't have.