### PR TITLE
Fix: Garbage collection interval not set

### DIFF
--- a/pyqttoolkit/application/application.py
+++ b/pyqttoolkit/application/application.py
@@ -30,7 +30,7 @@ class Application(QApplication):
     def __init__(self, argv):
         QApplication.__init__(self, argv)
         self._dependency_container = DependencyContainer()
-        self._garbage_collector = GarbageCollector(self, None)
+        self._garbage_collector = GarbageCollector(self)
 
         self._module_service = None
         self._message_board = None


### PR DESCRIPTION
Resolves https://github.com/BitBloomTech/Sift/issues/2822

Garbage collection interval was not set and then the collection wasn't happening periodically as it was supposed to happen -garbage collection was basically disabled during the application execution and almost never happening which sounds pretty bad. 

This, actually, would explain/fix other memory errors in the application (some of them already fixed enforcing a garbage collection).